### PR TITLE
Use ADD instead of Curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,9 @@ FROM base AS build
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION=7.88.1-10+deb12u6
-
-RUN apt-get update -y && \
-  # Install necessary dependencies
-  apt-get install -y --no-install-recommends curl=${CURL_VERSION} && \
-  # Add .NET PPA
-  curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb && \
-  dpkg -i /tmp/packages-microsoft-prod.deb && \
+# Add .NET PPA
+ADD https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb /tmp/packages-microsoft-prod.deb
+RUN  dpkg -i /tmp/packages-microsoft-prod.deb && \
   rm -rf /tmp/*
 
 # Final image


### PR DESCRIPTION
Use ADD instead of Curl to install the .NET PPA.

Fixes https://rules.sonarsource.com/docker/RSPEC-7026/